### PR TITLE
Public API now uses curly_hpp::response_code instead of uint16_t  for HTTP response codes.

### DIFF
--- a/headers/curly.hpp/curly.hpp
+++ b/headers/curly.hpp/curly.hpp
@@ -28,6 +28,7 @@
 #include <vector>
 #include <string>
 #include <initializer_list>
+#include "response_code.h"
 
 namespace curly_hpp
 {
@@ -198,8 +199,8 @@ namespace curly_hpp
             return last_url_;
         }
 
-        http_code_t http_code() const noexcept {
-            return http_code_;
+        [[nodiscard]] response_code http_code() const noexcept {
+            return static_cast<response_code>(http_code_);
         }
     public:
         content_t content;

--- a/headers/curly.hpp/response_code.h
+++ b/headers/curly.hpp/response_code.h
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * This file is part of the "https://github.com/blackmatov/curly.hpp"
+ * For conditions of distribution and use, see copyright notice in LICENSE.md
+ * Copyright (C) 2019, by Matvey Cherevko (blackmatov@gmail.com)
+ * Copyright (C) 2019, by Per Malmberg (https://github.com/PerMalmberg)
+ ******************************************************************************/
+
+#pragma once
+#include <ostream>
+#include <unordered_map>
+
+namespace curly_hpp
+{
+    enum class response_code
+    {
+        // Informational = 1××
+        Continue = 100,
+        SwitchingProtocols = 101,
+        Processing = 102,
+        
+        //_Success = 2××
+        OK = 200,
+        Created = 201,
+        Accepted = 202,
+        Non_authoritativeInformation = 203,
+        No_Content = 204,
+        Reset_Content = 205,
+        Partial_Content = 206,
+        Multi_Status = 207,
+        Already_Reported = 208,
+        IM_Used = 226,
+        
+        //_Redirection = 3××
+        Multiple_Choices = 300,
+        Moved_Permanently = 301,
+        Found = 302,
+        See_Other = 303,
+        Not_Modified = 304,
+        Use_Proxy = 305,
+        Temporary_Redirect = 307,
+        Permanent_Redirect = 308,
+        
+        //_Client_Error = 4××
+        Bad_Request = 400,
+        Unauthorized = 401,
+        Payment_Required = 402,
+        Forbidden = 403,
+        Not_Found = 404,
+        Method_Not_Allowed = 405,
+        Not_Acceptable = 406,
+        Proxy_Authentication_Required = 407,
+        Request_Timeout = 408,
+        Conflict = 409,
+        Gone = 410,
+        Length_Required = 411,
+        Precondition_Failed = 412,
+        Payload_Too_Large = 413,
+        Request_URI_Too_Long = 414,
+        Unsupported_Media_Type = 415,
+        Requested_Range_Not_Satisfiable = 416,
+        Expectation_Failed = 417,
+        Im_a_teapot = 418,
+        Misdirected_Request = 421,
+        Unprocessable_Entity = 422,
+        Locked = 423,
+        Failed_Dependency = 424,
+        Upgrade_Required = 426,
+        Precondition_Required = 428,
+        Too_Many_Requests = 429,
+        Request_Header_Fields_Too_Large = 431,
+        Connection_Closed_Without_Response = 444,
+        Unavailable_For_Legal_Reasons = 451,
+        Client_Closed_Request = 499,
+        
+        //_Server_Error = 5××
+        Internal_Server_Error = 500,
+        Not_Implemented = 501,
+        Bad_Gateway = 502,
+        Service_Unavailable = 503,
+        Gateway_Timeout = 504,
+        HTTP_Version_Not_Supported = 505,
+        Variant_Also_Negotiates = 506,
+        Insufficient_Storage = 507,
+        Loop_Detected = 508,
+        Not_Extended = 510,
+        Network_Authentication_Required = 511,
+        Network_Connect_Timeout_Error = 599
+    };
+
+    const std::unordered_map<response_code, const char*> response_code_to_text = {
+            {response_code::Continue,                           "Continue"},
+            {response_code::SwitchingProtocols,                 "Switching Protocols"},
+            {response_code::Processing,                         "Processing"},
+            {response_code::OK,                                 "OK"},
+            {response_code::Created,                            "Created"},
+            {response_code::Accepted,                           "Accepted"},
+            {response_code::Non_authoritativeInformation,       "Non-Authoritative Information"},
+            {response_code::No_Content,                         "No Content"},
+            {response_code::Reset_Content,                      "Reset Content"},
+            {response_code::Partial_Content,                    "Partial Content"},
+            {response_code::Multi_Status,                       "Multi Status"},
+            {response_code::Already_Reported,                   "Already Reported"},
+            {response_code::IM_Used,                            "IM Used"},
+            {response_code::Multiple_Choices,                   "Multiple Choices"},
+            {response_code::Moved_Permanently,                  "Moved Permanently"},
+            {response_code::Found,                              "Found"},
+            {response_code::See_Other,                          "See Other"},
+            {response_code::Not_Modified,                       "Not Modified"},
+            {response_code::Use_Proxy,                          "Use Proxy"},
+            {response_code::Temporary_Redirect,                 "Temporary Redirect"},
+            {response_code::Permanent_Redirect,                 "Permanent Redirect"},
+            {response_code::Bad_Request,                        "Bad Request"},
+            {response_code::Unauthorized,                       "Unauthorized"},
+            {response_code::Payment_Required,                   "Payment Required"},
+            {response_code::Forbidden,                          "Forbidden"},
+            {response_code::Not_Found,                          "Not Found"},
+            {response_code::Method_Not_Allowed,                 "Method Not Allowed"},
+            {response_code::Not_Acceptable,                     "Not Acceptable"},
+            {response_code::Proxy_Authentication_Required,      "Proxy Authentication Required"},
+            {response_code::Request_Timeout,                    "Request Timeout"},
+            {response_code::Conflict,                           "Conflict"},
+            {response_code::Gone,                               "Gone"},
+            {response_code::Length_Required,                    "Length Required"},
+            {response_code::Precondition_Failed,                "Precondition Failed"},
+            {response_code::Payload_Too_Large,                  "Payload Too Large"},
+            {response_code::Request_URI_Too_Long,               "Request URI Too Long"},
+            {response_code::Unsupported_Media_Type,             "Unsupported Media Type"},
+            {response_code::Requested_Range_Not_Satisfiable,    "Requested Range Not Satisfiable"},
+            {response_code::Expectation_Failed,                 "Expectation Failed"},
+            {response_code::Im_a_teapot,                        "I'm a teapot"},
+            {response_code::Misdirected_Request,                "Misdirected Request"},
+            {response_code::Unprocessable_Entity,               "Unprocessable Entity"},
+            {response_code::Locked,                             "Locked"},
+            {response_code::Failed_Dependency,                  "Failed Dependency"},
+            {response_code::Upgrade_Required,                   "Upgrade Required"},
+            {response_code::Precondition_Required,              "Precondition Required"},
+            {response_code::Too_Many_Requests,                  "Too Many Requests"},
+            {response_code::Request_Header_Fields_Too_Large,    "Request Header Fields Too Large"},
+            {response_code::Connection_Closed_Without_Response, "Connection Closed Without Response"},
+            {response_code::Unavailable_For_Legal_Reasons,      "Unavailable For Legal Reasons"},
+            {response_code::Client_Closed_Request,              "Client Closed Request"},
+            {response_code::Internal_Server_Error,              "Internal Server Error"},
+            {response_code::Not_Implemented,                    "Not Implemented"},
+            {response_code::Bad_Gateway,                        "Bad Gateway"},
+            {response_code::Service_Unavailable,                "Service Unavailable"},
+            {response_code::Gateway_Timeout,                    "Gateway Timeout"},
+            {response_code::HTTP_Version_Not_Supported,         "HTTP Version Not Supported"},
+            {response_code::Variant_Also_Negotiates,            "Variant Also Negotiates"},
+            {response_code::Insufficient_Storage,               "Insufficient Storage"},
+            {response_code::Loop_Detected,                      "Loop Detected"},
+            {response_code::Not_Extended,                       "Not Extended"},
+            {response_code::Network_Authentication_Required,    "Network Authentication Required"},
+            {response_code::Network_Connect_Timeout_Error,      "Network Connect Timeout Error"}
+    };
+
+    std::string as_string(response_code code);
+}
+
+std::ostream& operator<<(std::ostream& stream, curly_hpp::response_code c);

--- a/sources/curly.hpp/response_code.cpp
+++ b/sources/curly.hpp/response_code.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * This file is part of the "https://github.com/blackmatov/curly.hpp"
+ * For conditions of distribution and use, see copyright notice in LICENSE.md
+* Copyright (C) 2019, by Matvey Cherevko (blackmatov@gmail.com)
+ * Copyright (C) 2019, by Per Malmberg (https://github.com/PerMalmberg)
+ ******************************************************************************/
+
+#include <curly.hpp/response_code.h>
+
+namespace curly_hpp
+{
+    std::string as_string(response_code code)
+    {
+        try
+        {
+            return response_code_to_text.at(code);
+        }
+        catch (...)
+        {
+            return "Invalid response code";
+        }
+    }
+}
+
+std::ostream& operator<<(std::ostream& stream, curly_hpp::response_code c)
+{
+    stream << static_cast<int>(c);
+    return stream;
+}

--- a/untests/curly_tests.cpp
+++ b/untests/curly_tests.cpp
@@ -119,14 +119,14 @@ TEST_CASE("curly") {
             REQUIRE(req.wait() == net::req_status::done);
             REQUIRE(req.status() == net::req_status::done);
             auto resp = req.take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(req.status() == net::req_status::empty);
         }
         {
             auto req = net::request_builder("https://httpbin.org/delay/2").send();
             REQUIRE(req.wait_for(net::time_sec_t(1)) == net::req_status::pending);
             REQUIRE(req.wait_for(net::time_sec_t(5)) == net::req_status::done);
-            REQUIRE(req.take().http_code() == 200u);
+            REQUIRE(req.take().http_code() == net::response_code::OK);
         }
         {
             auto req = net::request_builder("https://httpbin.org/delay/2").send();
@@ -134,7 +134,7 @@ TEST_CASE("curly") {
                 == net::req_status::pending);
             REQUIRE(req.wait_until(net::time_point_t::clock::now() + net::time_sec_t(5))
                 == net::req_status::done);
-            REQUIRE(req.take().http_code() == 200u);
+            REQUIRE(req.take().http_code() == net::response_code::OK);
         }
     }
 
@@ -191,7 +191,7 @@ TEST_CASE("curly") {
             auto req = net::request_builder("https://httpbin.org/status/204").send();
             auto resp = req.take();
             REQUIRE(req.status() == net::req_status::empty);
-            REQUIRE(resp.http_code() == 204u);
+            REQUIRE(resp.http_code() == net::response_code::No_Content);
             REQUIRE(resp.last_url() == "https://httpbin.org/status/204");
         }
         {
@@ -216,111 +216,111 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/put")
                 .method(net::http_method::PUT)
                 .send();
-            REQUIRE(req0.take().http_code() == 200u);
+            REQUIRE(req0.take().http_code() == net::response_code::OK);
 
             auto req1 = net::request_builder()
                 .url("https://httpbin.org/put")
                 .method(net::http_method::GET)
                 .send();
-            REQUIRE(req1.take().http_code() == 405u);
+            REQUIRE(req1.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req2 = net::request_builder()
                 .url("https://httpbin.org/put")
                 .method(net::http_method::HEAD)
                 .send();
-            REQUIRE(req2.take().http_code() == 405u);
+            REQUIRE(req2.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req3 = net::request_builder()
                 .url("https://httpbin.org/put")
                 .method(net::http_method::POST)
                 .send();
-            REQUIRE(req3.take().http_code() == 405u);
+            REQUIRE(req3.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req4 = net::request_builder()
                 .url("https://httpbin.org/put")
                 .method(net::http_method::PATCH)
                 .send();
-            REQUIRE(req4.take().http_code() == 405u);
+            REQUIRE(req4.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req5 = net::request_builder()
                 .url("https://httpbin.org/put")
                 .method(net::http_method::DEL)
                 .send();
-            REQUIRE(req5.take().http_code() == 405u);
+            REQUIRE(req5.take().http_code() == net::response_code::Method_Not_Allowed);
         }
         {
             auto req0 = net::request_builder()
                 .url("https://httpbin.org/get")
                 .method(net::http_method::PUT)
                 .send();
-            REQUIRE(req0.take().http_code() == 405u);
+            REQUIRE(req0.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req1 = net::request_builder()
                 .url("https://httpbin.org/get")
                 .method(net::http_method::GET)
                 .send();
-            REQUIRE(req1.take().http_code() == 200u);
+            REQUIRE(req1.take().http_code() == net::response_code::OK);
 
             auto req2 = net::request_builder()
                 .url("https://httpbin.org/get")
                 .method(net::http_method::HEAD)
                 .send();
-            REQUIRE(req2.take().http_code() == 200u);
+            REQUIRE(req2.take().http_code() == net::response_code::OK);
 
             auto req3 = net::request_builder()
                 .url("https://httpbin.org/get")
                 .method(net::http_method::POST)
                 .send();
-            REQUIRE(req3.take().http_code() == 405u);
+            REQUIRE(req3.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req4 = net::request_builder()
                 .url("https://httpbin.org/get")
                 .method(net::http_method::PATCH)
                 .send();
-            REQUIRE(req4.take().http_code() == 405u);
+            REQUIRE(req4.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req5 = net::request_builder()
                 .url("https://httpbin.org/get")
                 .method(net::http_method::DEL)
                 .send();
-            REQUIRE(req5.take().http_code() == 405u);
+            REQUIRE(req5.take().http_code() == net::response_code::Method_Not_Allowed);
         }
         {
             auto req0 = net::request_builder()
                 .url("https://httpbin.org/post")
                 .method(net::http_method::PUT)
                 .send();
-            REQUIRE(req0.take().http_code() == 405u);
+            REQUIRE(req0.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req1 = net::request_builder()
                 .url("https://httpbin.org/post")
                 .method(net::http_method::GET)
                 .send();
-            REQUIRE(req1.take().http_code() == 405u);
+            REQUIRE(req1.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req2 = net::request_builder()
                 .url("https://httpbin.org/post")
                 .method(net::http_method::HEAD)
                 .send();
-            REQUIRE(req2.take().http_code() == 405u);
+            REQUIRE(req2.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req3 = net::request_builder()
                 .url("https://httpbin.org/post")
                 .method(net::http_method::POST)
                 .send();
-            REQUIRE(req3.take().http_code() == 200u);
+            REQUIRE(req3.take().http_code() == net::response_code::OK);
 
             auto req4 = net::request_builder()
                 .url("https://httpbin.org/post")
                 .method(net::http_method::PATCH)
                 .send();
-            REQUIRE(req4.take().http_code() == 405u);
+            REQUIRE(req4.take().http_code() == net::response_code::Method_Not_Allowed);
 
             auto req5 = net::request_builder()
                 .url("https://httpbin.org/post")
                 .method(net::http_method::DEL)
                 .send();
-            REQUIRE(req5.take().http_code() == 405u);
+            REQUIRE(req5.take().http_code() == net::response_code::Method_Not_Allowed);
         }
         {
             auto req1 = net::request_builder()
@@ -345,42 +345,42 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/status/200")
                 .method(net::http_method::PUT)
                 .send();
-            REQUIRE(req.take().http_code() == 200u);
+            REQUIRE(req.take().http_code() == net::response_code::OK);
         }
         {
             auto req = net::request_builder()
                 .url("https://httpbin.org/status/201")
                 .method(net::http_method::GET)
                 .send();
-            REQUIRE(req.take().http_code() == 201u);
+            REQUIRE(req.take().http_code() == net::response_code::Created);
         }
         {
             auto req = net::request_builder()
                 .url("https://httpbin.org/status/202")
                 .method(net::http_method::HEAD)
                 .send();
-            REQUIRE(req.take().http_code() == 202u);
+            REQUIRE(req.take().http_code() == net::response_code::Accepted);
         }
         {
             auto req = net::request_builder()
                 .url("https://httpbin.org/status/203")
                 .method(net::http_method::POST)
                 .send();
-            REQUIRE(req.take().http_code() == 203u);
+            REQUIRE(req.take().http_code() == net::response_code::Non_authoritativeInformation);
         }
         {
             auto req = net::request_builder()
                 .url("https://httpbin.org/status/203")
                 .method(net::http_method::PATCH)
                 .send();
-            REQUIRE(req.take().http_code() == 203u);
+            REQUIRE(req.take().http_code() == net::response_code::Non_authoritativeInformation);
         }
         {
             auto req = net::request_builder()
                 .url("https://httpbin.org/status/203")
                 .method(net::http_method::DEL)
                 .send();
-            REQUIRE(req.take().http_code() == 203u);
+            REQUIRE(req.take().http_code() == net::response_code::Non_authoritativeInformation);
         }
     }
 
@@ -552,7 +552,7 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/bytes/5")
                 .method(net::http_method::GET)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.content.size() == 5u);
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
@@ -564,7 +564,7 @@ TEST_CASE("curly") {
                 .url("http://httpbin.org/drip?duration=2&numbytes=5&code=200&delay=1")
                 .method(net::http_method::GET)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.content.size() == 5u);
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
@@ -585,7 +585,7 @@ TEST_CASE("curly") {
                 .url("http://httpbin.org/base64/SFRUUEJJTiBpcyBhd2Vzb21l")
                 .method(net::http_method::GET)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.content.as_string_view() == "HTTPBIN is awesome");
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
@@ -597,7 +597,7 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/image/png")
                 .method(net::http_method::HEAD)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
             REQUIRE(resp.headers.at("Content-Type") == "image/png");
@@ -609,7 +609,7 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/image/png")
                 .method(net::http_method::GET)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
             REQUIRE(resp.headers.at("Content-Type") == "image/png");
@@ -624,7 +624,7 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/image/jpeg")
                 .method(net::http_method::HEAD)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
             REQUIRE(resp.headers.at("Content-Type") == "image/jpeg");
@@ -636,7 +636,7 @@ TEST_CASE("curly") {
                 .url("https://httpbin.org/image/jpeg")
                 .method(net::http_method::GET)
                 .send().take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
             REQUIRE(resp.headers.count("Content-Type"));
             REQUIRE(resp.headers.count("Content-Length"));
             REQUIRE(resp.headers.at("Content-Type") == "image/jpeg");
@@ -655,21 +655,21 @@ TEST_CASE("curly") {
                     .url("https://httpbin.org/redirect/2")
                     .method(net::http_method::GET)
                     .send();
-                REQUIRE(req.take().http_code() == 200u);
+                REQUIRE(req.take().http_code() == net::response_code::OK);
             }
             {
                 auto req = net::request_builder()
                     .url("https://httpbin.org/absolute-redirect/2")
                     .method(net::http_method::GET)
                     .send();
-                REQUIRE(req.take().http_code() == 200u);
+                REQUIRE(req.take().http_code() == net::response_code::OK);
             }
             {
                 auto req = net::request_builder()
                     .url("https://httpbin.org/relative-redirect/2")
                     .method(net::http_method::GET)
                     .send();
-                REQUIRE(req.take().http_code() == 200u);
+                REQUIRE(req.take().http_code() == net::response_code::OK);
             }
         }
         {
@@ -679,7 +679,7 @@ TEST_CASE("curly") {
                     .method(net::http_method::GET)
                     .redirections(0)
                     .send();
-                REQUIRE(req.take().http_code() == 302u);
+                REQUIRE(req.take().http_code() == net::response_code::Found);
             }
             {
                 auto req = net::request_builder()
@@ -703,7 +703,7 @@ TEST_CASE("curly") {
                     .method(net::http_method::GET)
                     .redirections(3)
                     .send();
-                REQUIRE(req.take().http_code() == 200u);
+                REQUIRE(req.take().http_code() == net::response_code::OK);
             }
         }
     }
@@ -851,7 +851,7 @@ TEST_CASE("curly") {
                     ++call_once;
                     REQUIRE(request.is_done());
                     REQUIRE(request.status() == net::req_status::done);
-                    REQUIRE(request.take().http_code() == 200u);
+                    REQUIRE(request.take().http_code() == net::response_code::OK);
                 }).send();
             REQUIRE(req.wait_callback() == net::req_status::empty);
             REQUIRE_FALSE(req.get_callback_exception());
@@ -1105,11 +1105,11 @@ TEST_CASE("proxy") {
             try {
                 auto ipinfo_resp = ipinfo_req.take();
                 ipinfo = json_parse(ipinfo_resp.content.as_string_view());
-                REQUIRE(ipinfo_resp.http_code() == 200u);
+                REQUIRE(ipinfo_resp.http_code() == net::response_code::OK);
             }
             catch (net::exception& e)
             {
-                auto error = ipinfo_req.get_error();
+                const auto& error = ipinfo_req.get_error();
                 FAIL("Request failed with: " + error);
             }
 
@@ -1122,14 +1122,16 @@ TEST_CASE("proxy") {
                 try {
                     const auto resp = req.take();
                     const auto resp_content = json_parse(resp.content.as_string_view());
-                    REQUIRE(resp.http_code() == 200u);
+
+                    REQUIRE(resp.http_code() == net::response_code::OK);
+
                     std::string left{resp_content["headers"]["X-Real-Ip"].GetString()};
                     std::string right{ipinfo["ip"].GetString()};
                     REQUIRE(left == right);
                 }
                 catch (net::exception& e)
                 {
-                    auto error = req.get_error();
+                    const auto& error = req.get_error();
                     FAIL("Request failed with: " + error);
                 }
             }
@@ -1148,7 +1150,7 @@ TEST_CASE("proxy") {
                         .send();
                 const auto resp = req.take();
                 const auto resp_content = json_parse(resp.content.as_string_view());
-                REQUIRE(resp.http_code() == 200u);
+                REQUIRE(resp.http_code() == net::response_code::OK);
                 std::string left{resp_content["headers"]["X-Real-Ip"].GetString()};
                 std::string right{ipinfo["ip"].GetString()};
                 REQUIRE(left != right);
@@ -1179,12 +1181,14 @@ SCENARIO("Public key authentication")
                     .url("https://client.badssl.com")
                     .method(net::http_method::GET)
                     .client_certificate("./badssl.com-client.p12", net::ssl_cert::P12, "badssl.com")
-                    .verification(true)
+                    // Depending on where curl is built, the location of certificates are different.
+                    // Ubuntu uses /etc/ssl/certs. On macOS no path is required since DarwinSSL uses the cert store.
+                    .verification(true, "/etc/ssl/certs")
                     .send();
             auto resp = req.take();
-            REQUIRE(resp.http_code() == 200u);
+            REQUIRE(resp.http_code() == net::response_code::OK);
         }
-        catch(std::exception& ex)
+        catch(curly_hpp::exception& ex)
         {
             FAIL(ex.what());
         }
@@ -1206,7 +1210,7 @@ SCENARIO("Allowing requests to be created in a context that goes of of scope")
                 request = curly_hpp::request_builder().url(url).send();
             }
 
-            curly_hpp::http_code_t get_result()
+            curly_hpp::response_code get_result()
             {
                 auto response = request.take();
                 return response.http_code();
@@ -1223,7 +1227,13 @@ SCENARIO("Allowing requests to be created in a context that goes of of scope")
         THEN("We initiate the request from a method")
         {
             scope.send();
-            REQUIRE(scope.get_result() == 200u);
+            REQUIRE(scope.get_result() == net::response_code::OK);
         }
     }
+}
+
+SCENARIO("Translating response codes")
+{
+    REQUIRE("OK" == net::as_string(net::response_code::OK));
+    REQUIRE("Invalid response code" == net::as_string(static_cast<net::response_code>(9999)));
 }


### PR DESCRIPTION
Public API now uses curly_hpp::response_code instead of uint16_t  for HTTP response codes.